### PR TITLE
Support @dependency annotation in lua files

### DIFF
--- a/test/assets/lua/segmentors/segmentor.lua
+++ b/test/assets/lua/segmentors/segmentor.lua
@@ -1,2 +1,3 @@
+--@dependency lua/extra.txt
 dofile('external')
 util = require('utils/util')

--- a/test/test-loader.spec.ts
+++ b/test/test-loader.spec.ts
@@ -142,6 +142,7 @@ it('Load recipe', async () => {
     'child.dict.yaml',
     'lua/external.lua',
     'lua/external/init.lua',
+    'lua/extra.txt',
     'lua/processor.lua',
     'lua/processor/init.lua',
     'lua/segmentors/segmentor.lua',

--- a/test/test-parser.spec.ts
+++ b/test/test-parser.spec.ts
@@ -77,7 +77,8 @@ const luaCases = {
   ],
   'lua/segmentors/segmentor.lua': [
     ['lua/external.lua', 'lua/external/init.lua'],
-    ['lua/utils/util.lua', 'lua/utils/util/init.lua']
+    ['lua/utils/util.lua', 'lua/utils/util/init.lua'],
+    ['lua/extra.txt']
   ]
 }
 


### PR DESCRIPTION
Lua scripts can depend on extra data files. Add `@dependency` annotation to allow declaration of such dependencies.